### PR TITLE
Fix countdown year calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,8 @@
 
                 countDate.setDate(8);
                 countDate.setMonth(0);
-                countDate.setFullYear(now.getFullYear() + (now.getMonth() === 0 && now.getDate() >= 8 ? 1 : 0));
+                const jan8ThisYear = new Date(now.getFullYear(), 0, 8);
+                countDate.setFullYear(now.getFullYear() + (now >= jan8ThisYear ? 1 : 0));
                 countDate.setHours(0);
                 countDate.setMinutes(0);
                 countDate.setSeconds(0);


### PR DESCRIPTION
## Summary
- prevent negative countdown after January by calculating next Jan 8 correctly

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6848320d0c648324b5f8d097b3b8ad40